### PR TITLE
Added the ability to upgrade an entire blueprint book at once

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -18,19 +18,19 @@ function get_type(entity)
 end
 
 function count_keys(hashmap)
-  
+
   local result = 0
-  
+
   for _, __ in pairs(hashmap) do
     result = result + 1
   end
-  
+
   return result
-  
+
 end
 
 function get_config_item(player, index, type)
-  
+
   if not global["config-tmp"][player.name]
   or index > #global["config-tmp"][player.name]
   or global["config-tmp"][player.name][index][type] == "" then
@@ -42,9 +42,9 @@ function get_config_item(player, index, type)
   if not game.item_prototypes[global["config-tmp"][player.name][index][type]].valid then
     return nil
   end
-  
+
   return game.item_prototypes[global["config-tmp"][player.name][index][type]].name
-  
+
 end
 
 function gui_init(player)
@@ -63,19 +63,19 @@ function gui_init(player)
 end
 
 function gui_open_frame(player)
-  
+
   local flow = player.gui.center
-  
+
   local frame = flow.upgrade_planner_config_frame
-  
+
   if frame then
     frame.destroy()
     global["config-tmp"][player.name] = nil
     return
   end
-  
-  
-  
+
+
+
   global.config[player.name] = global.config[player.name] or {}
   global["config-tmp"][player.name] = {}
   local i = 0
@@ -89,7 +89,7 @@ function gui_open_frame(player)
       }
     end
   end
-  
+
   -- Now we can build the GUI.
   frame = flow.add{
     type = "frame",
@@ -159,7 +159,7 @@ function gui_open_frame(player)
     name = "upgrade_planner_ruleset_grid",
     style = "slot_table"
   }
-  
+
   ruleset_grid.add{
     type = "label",
     caption = {"upgrade-planner.config-header-1"}
@@ -226,7 +226,7 @@ function gui_open_frame(player)
       tooltip = {"upgrade-planner.config-clear", ""}
     }
   end
-  
+
   local button_grid = frame.add{
     type = "table",
     column_count = 4
@@ -264,11 +264,11 @@ function gui_open_frame(player)
 end
 
 function gui_save_changes(player)
-  
+
   -- Saving changes consists in:
   --   1. copying config-tmp to config
   --   2. removing config-tmp
-  
+
   if global["config-tmp"][player.name] then
     local i = 0
     global.config[player.name] = {}
@@ -352,7 +352,7 @@ function gui_clear_rule(player, index)
 end
 
 function gui_restore(player, name)
-  
+
   local frame = player.gui.center.upgrade_planner_config_frame
   if not frame then return end
   if not global.storage[player.name] then return end
@@ -361,7 +361,7 @@ function gui_restore(player, name)
     storage = {}
   end
   if not storage then return end
-  
+
   global["config-tmp"][player.name] = {}
   local items = game.item_prototypes
   local i = 0
@@ -392,11 +392,11 @@ function gui_restore(player, name)
     end
   end
   global.config[player.name] = global["config-tmp"][player.name]
-  
+
 end
 
 script.on_event(defines.events.on_gui_click, function(event)
-  
+
   local element = event.element
   --print_full_gui_name(element)
   local name = element.name
@@ -424,7 +424,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     player.cursor_stack.set_stack({name = "upgrade-builder"})
     return
   end
-  
+
   if name == "upgrade_planner_storage_rename" then
     local children = element.parent.children
     for k, child in pairs (children) do
@@ -436,7 +436,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     end
     return
   end
-  
+
   if name == "upgrade_planner_storage_cancel" then
     local children = element.parent.children
     for k = 4, 6 do
@@ -445,7 +445,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     children[4].text = children[1].get_item(children[1].selected_index)
     return
   end
-  
+
   if name == "upgrade_planner_storage_confirm" then
     local index = global.storage_index[player.name]
     local children = element.parent.children
@@ -485,7 +485,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     global.storage_index[player.name] = index
     return
   end
-  
+
   if name == "upgrade_planner_storage_delete" then
     local children = element.parent.children
     local dropdown = children[1]
@@ -532,7 +532,7 @@ script.on_event(defines.events.on_gui_click, function(event)
       return
     end
   end
-  
+
 end)
 
 script.on_event(defines.events.on_gui_selection_state_changed, function(event)
@@ -548,7 +548,7 @@ script.on_event(defines.events.on_gui_selection_state_changed, function(event)
 end)
 
 script.on_event(defines.events.on_gui_elem_changed, function(event)
-  
+
   local element = event.element
   local player = game.players[event.player_index]
   if not string.find(element.name, "upgrade_planner_") then return end
@@ -574,7 +574,7 @@ end)
 
 function on_selected_area(event)
   if event.item ~= "upgrade-builder" then return end--If its a upgrade builder
-  
+
   local player = game.players[event.player_index]
   local config = global.config[player.name]
   if config == nil then return end
@@ -892,11 +892,11 @@ function bot_upgrade(player, belt, upgrade, bool, hashmap)
   local f = belt.force
   local p = belt.position
   local a = {{p.x-0.5,p.y-0.5},{p.x+0.5,p.y+0.5}}
-  
+
   if belt.to_be_deconstructed(f) then
     return
   end
-  
+
   if belt.type == "underground-belt" then
     if belt.neighbours and bool then
       bot_upgrade(player,belt.neighbours, upgrade, false)
@@ -1104,7 +1104,7 @@ function is_exception(from, to)
 end
 
 script.on_event("upgrade-planner", function(event)
-  local player = game.players[event.player_index] 
+  local player = game.players[event.player_index]
   gui_open_frame(player)
 end)
 

--- a/control.lua
+++ b/control.lua
@@ -18,19 +18,19 @@ function get_type(entity)
 end
 
 function count_keys(hashmap)
-
+  
   local result = 0
-
+  
   for _, __ in pairs(hashmap) do
     result = result + 1
   end
-
+  
   return result
-
+  
 end
 
 function get_config_item(player, index, type)
-
+  
   if not global["config-tmp"][player.name]
   or index > #global["config-tmp"][player.name]
   or global["config-tmp"][player.name][index][type] == "" then
@@ -42,9 +42,9 @@ function get_config_item(player, index, type)
   if not game.item_prototypes[global["config-tmp"][player.name][index][type]].valid then
     return nil
   end
-
+  
   return game.item_prototypes[global["config-tmp"][player.name][index][type]].name
-
+  
 end
 
 function gui_init(player)
@@ -63,19 +63,19 @@ function gui_init(player)
 end
 
 function gui_open_frame(player)
-
+  
   local flow = player.gui.center
-
+  
   local frame = flow.upgrade_planner_config_frame
-
+  
   if frame then
     frame.destroy()
     global["config-tmp"][player.name] = nil
     return
   end
-
-
-
+  
+  
+  
   global.config[player.name] = global.config[player.name] or {}
   global["config-tmp"][player.name] = {}
   local i = 0
@@ -89,7 +89,7 @@ function gui_open_frame(player)
       }
     end
   end
-
+  
   -- Now we can build the GUI.
   frame = flow.add{
     type = "frame",
@@ -159,7 +159,7 @@ function gui_open_frame(player)
     name = "upgrade_planner_ruleset_grid",
     style = "slot_table"
   }
-
+  
   ruleset_grid.add{
     type = "label",
     caption = {"upgrade-planner.config-header-1"}
@@ -226,7 +226,7 @@ function gui_open_frame(player)
       tooltip = {"upgrade-planner.config-clear", ""}
     }
   end
-
+  
   local button_grid = frame.add{
     type = "table",
     column_count = 4
@@ -264,11 +264,11 @@ function gui_open_frame(player)
 end
 
 function gui_save_changes(player)
-
+  
   -- Saving changes consists in:
   --   1. copying config-tmp to config
   --   2. removing config-tmp
-
+  
   if global["config-tmp"][player.name] then
     local i = 0
     global.config[player.name] = {}
@@ -352,7 +352,7 @@ function gui_clear_rule(player, index)
 end
 
 function gui_restore(player, name)
-
+  
   local frame = player.gui.center.upgrade_planner_config_frame
   if not frame then return end
   if not global.storage[player.name] then return end
@@ -361,7 +361,7 @@ function gui_restore(player, name)
     storage = {}
   end
   if not storage then return end
-
+  
   global["config-tmp"][player.name] = {}
   local items = game.item_prototypes
   local i = 0
@@ -392,27 +392,39 @@ function gui_restore(player, name)
     end
   end
   global.config[player.name] = global["config-tmp"][player.name]
-
+  
 end
 
 script.on_event(defines.events.on_gui_click, function(event)
-
+  
   local element = event.element
   --print_full_gui_name(element)
   local name = element.name
   local player = game.players[event.player_index]
-  --game.print(element.type)
-  --game.print(element.name)
+  local config = global.config[player.name]
+
   if name == "upgrade_blueprint" then
-    upgrade_blueprint(player)
+    local stack = player.cursor_stack
+    if not (stack and stack.valid and stack.valid_for_read) then return end
+    if stack.is_blueprint and upgrade_blueprint(config, stack) then
+      player.print({"upgrade-planner.blueprint-upgrade-successful"})
+    elseif stack.is_blueprint_book then
+      local inv = stack.get_inventory(defines.inventory.item_main)
+      local result = true
+      for i = 1, inv.get_item_count() do
+        result = result and upgrade_blueprint(config, inv[i])
+      end
+      if result then player.print({"upgrade-planner.blueprint-book-upgrade-successful"}) end
+    end
     return
   end
+
   if name == "give_upgrade_tool" then
     player.clean_cursor()
     player.cursor_stack.set_stack({name = "upgrade-builder"})
     return
   end
-
+  
   if name == "upgrade_planner_storage_rename" then
     local children = element.parent.children
     for k, child in pairs (children) do
@@ -424,7 +436,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     end
     return
   end
-
+  
   if name == "upgrade_planner_storage_cancel" then
     local children = element.parent.children
     for k = 4, 6 do
@@ -433,7 +445,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     children[4].text = children[1].get_item(children[1].selected_index)
     return
   end
-
+  
   if name == "upgrade_planner_storage_confirm" then
     local index = global.storage_index[player.name]
     local children = element.parent.children
@@ -473,7 +485,7 @@ script.on_event(defines.events.on_gui_click, function(event)
     global.storage_index[player.name] = index
     return
   end
-
+  
   if name == "upgrade_planner_storage_delete" then
     local children = element.parent.children
     local dropdown = children[1]
@@ -520,7 +532,7 @@ script.on_event(defines.events.on_gui_click, function(event)
       return
     end
   end
-
+  
 end)
 
 script.on_event(defines.events.on_gui_selection_state_changed, function(event)
@@ -536,7 +548,7 @@ script.on_event(defines.events.on_gui_selection_state_changed, function(event)
 end)
 
 script.on_event(defines.events.on_gui_elem_changed, function(event)
-
+  
   local element = event.element
   local player = game.players[event.player_index]
   if not string.find(element.name, "upgrade_planner_") then return end
@@ -562,7 +574,7 @@ end)
 
 function on_selected_area(event)
   if event.item ~= "upgrade-builder" then return end--If its a upgrade builder
-
+  
   local player = game.players[event.player_index]
   local config = global.config[player.name]
   if config == nil then return end
@@ -880,11 +892,11 @@ function bot_upgrade(player, belt, upgrade, bool, hashmap)
   local f = belt.force
   local p = belt.position
   local a = {{p.x-0.5,p.y-0.5},{p.x+0.5,p.y+0.5}}
-
+  
   if belt.to_be_deconstructed(f) then
     return
   end
-
+  
   if belt.type == "underground-belt" then
     if belt.neighbours and bool then
       bot_upgrade(player,belt.neighbours, upgrade, false)
@@ -995,22 +1007,14 @@ script.on_event(defines.events.on_player_joined_game, function(event)
   gui_init(player)
 end)
 
-function upgrade_blueprint(player)
-  local stack = player.cursor_stack
-  if not stack.valid then
-    return
-  end
-  if not stack.valid_for_read then
-    return
-  end
-  if stack.name ~= "blueprint" then
-    return
-  end
-  if not stack.is_blueprint_setup() then
-    return
-  end
-  local config = global.config[player.name]
-  if not config then return end
+function upgrade_blueprint(config, stack)
+  if not config then return false end
+  if not stack then return false end
+  if not stack.valid then return false end
+  if not stack.valid_for_read then return false end
+  if not stack.is_blueprint then return false end
+  if not stack.is_blueprint_setup() then return false end
+
   local hashmap = get_hashmap(config)
   local entities = stack.get_blueprint_entities()
   if entities then
@@ -1082,7 +1086,7 @@ function upgrade_blueprint(player)
     if new and new.item_to then icons[k].signal.name = new.item_to end
   end
   stack.blueprint_icons = icons
-  player.print({"upgrade-planner.blueprint-upgrade-successful"})
+  return true
 end
 
 function is_exception(from, to)
@@ -1100,7 +1104,7 @@ function is_exception(from, to)
 end
 
 script.on_event("upgrade-planner", function(event)
-  local player = game.players[event.player_index]
+  local player = game.players[event.player_index] 
   gui_open_frame(player)
 end)
 

--- a/info.json
+++ b/info.json
@@ -1,8 +1,8 @@
 {
     "name": "upgrade-planner",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "title": "Upgrade Builder and Planner",
-    "author": "Klonan",
+    "author": "Klonan & Fred4106",
     "description": "Automatically upgrade buildings by hand or with construction robots.",
     "homepage": "https://forums.factorio.com/viewtopic.php?f=92&t=14781",
     "factorio_version": "0.16"

--- a/locale/en/all.cfg
+++ b/locale/en/all.cfg
@@ -19,11 +19,12 @@ item-already-set=This item is already set in 'Upgrade from' column
 item-not-same-type=Items in one row must be the same type.
 item-is-same=You can't set the same item twice in one row.
 button-tooltip=Toggle upgrade planner frame
-config-button-upgrade-blueprint=Click a blueprint here to upgrade the entities inside.
+config-button-upgrade-blueprint=Click a blueprint or blueprint-book here to upgrade the entities inside.
 config-button-give-upgrade-tool=Click here to get an upgrade planning tool.
 config-button-import-config=Click to open a dialog where you can import a config.
 config-button-export-config=Click here to export your config as a string.
 blueprint-upgrade-successful=Blueprint upgrade successful.
+blueprint-book-upgrade-successful=Blueprint book upgrade successful.
 
 [item-name]
 upgrade-builder=Upgrade planner


### PR DESCRIPTION
Rewrote the signature of the function "upgrade-blueprint" so that it acts with a given configuration on a given itemstack instead of taking a player.  Moved code for getting the current players item in hand from upgrade-blueprint to the event dispatcher function. Added code to detect a blueprint-book and iterate/upgrade all children blueprints it contains.